### PR TITLE
UWP: Add full permission support for Documents, use native FilePicker

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using StereoKit;
 using StereoKit.Framework;
 
@@ -10,7 +9,6 @@ namespace StereoKitPaintTutorial
         static Painting    activePainting = new Painting();
         static PaletteMenu paletteMenu;
         static Pose        menuPose       = new Pose(new Vec3(0.4f, 0, -0.4f), Quat.LookDir(-1,0,1));
-        static string      defaultFolder  = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
         static void Main(string[] args)
         {
@@ -70,21 +68,16 @@ namespace StereoKitPaintTutorial
             // name and folder have been selected, it'll make a call to SavePainting with the
             // file's path name with the .skp extension.
             if (UI.Button("Save"))
-                FilePicker.Show(
-                    FilePickerMode.Save,
-                    defaultFolder,
-                    SavePainting,
-                    new FileFilter("Painting", "*.skp"));
+                TextToFromFileWithFilePicker.Save(activePainting.ToFileData());
 
             // And on that same line, we'll have a load button! This'll let the user pick out
             // any .skp files, and will call LoadPainting with the selected file.
             UI.SameLine();
             if (UI.Button("Load"))
-                FilePicker.Show(
-                    FilePickerMode.Open,
-                    defaultFolder,
-                    LoadPainting,
-                    new FileFilter("Painting", "*.skp"));
+                TextToFromFileWithFilePicker.Load((string text) =>
+                {
+                    activePainting = Painting.FromFile(text);
+                });
 
             // Clear is easy! Just create a new Painting object!
             if (UI.Button("Clear"))
@@ -98,12 +91,5 @@ namespace StereoKitPaintTutorial
             // And end the window!
             UI.WindowEnd();
         }
-
-        static void LoadPainting(string file)
-            => activePainting = Painting.FromFile(File.ReadAllText(file));
-        
-        static void SavePainting(string file)
-            => File.WriteAllText(file, activePainting.ToFileData());
-        
     }
 }

--- a/StereoKitPaintTutorial_UWP/Package.appxmanifest
+++ b/StereoKitPaintTutorial_UWP/Package.appxmanifest
@@ -46,6 +46,19 @@
         </uap:DefaultTile >
         <uap:SplashScreen Image="Assets\Logo\Logo-Wide300.png" />
       </uap:VisualElements>
+      <Extensions>
+        <uap:Extension Category="windows.fileTypeAssociation">
+          <uap:FileTypeAssociation Name=".skp">
+            <uap:DisplayName>StereoKit</uap:DisplayName>
+            <uap:SupportedFileTypes>
+              <uap:FileType>.skp</uap:FileType>
+            </uap:SupportedFileTypes>
+          </uap:FileTypeAssociation>
+        </uap:Extension>
+      </Extensions>
     </Application>
   </Applications>
+  <Capabilities>
+    <uap:Capability Name="documentsLibrary" />
+  </Capabilities>
 </Package>

--- a/StereoKitPaintTutorial_UWP/StereoKitPaintTutorial_UWP.csproj
+++ b/StereoKitPaintTutorial_UWP/StereoKitPaintTutorial_UWP.csproj
@@ -73,6 +73,7 @@
   <ItemGroup>
     <Compile Include="..\*.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TextToFromFileWithFilePickerUWP.cs" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">

--- a/StereoKitPaintTutorial_UWP/TextToFromFileWithFilePickerUWP.cs
+++ b/StereoKitPaintTutorial_UWP/TextToFromFileWithFilePickerUWP.cs
@@ -1,0 +1,51 @@
+#if WINDOWS_UWP
+using System;
+using System.Collections.Generic;
+using Windows.ApplicationModel.Core;
+using Windows.Storage;
+using Windows.Storage.Pickers;
+using Windows.UI.Core;
+
+namespace StereoKitPaintTutorial
+{
+    class TextToFromFileWithFilePicker
+    {
+        static CoreDispatcher uiDispatcher = CoreApplication.MainView.CoreWindow.Dispatcher;
+        static PickerLocationId pickerLocation = PickerLocationId.DocumentsLibrary;
+
+        public static async void Save(string fileData)
+        {
+            var picker = new FileSavePicker();
+            picker.FileTypeChoices.Add("StereoKit Paint", new List<string>(1) { ".skp" });
+            picker.DefaultFileExtension = ".skp";
+            picker.SuggestedFileName = "Painting.skp";
+            picker.SuggestedStartLocation = pickerLocation;
+            await uiDispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
+            {
+                var file = await picker.PickSaveFileAsync();
+                if (!file.IsAvailable) return;
+
+                await FileIO.WriteTextAsync(file, fileData);
+            });
+        }
+
+        public static async void Load(Action<string> callback)
+        {
+            var picker = new FileOpenPicker();
+            picker.ViewMode = PickerViewMode.Thumbnail;
+            picker.FileTypeFilter.Add(".skp");
+            picker.SuggestedStartLocation = pickerLocation;
+
+            await uiDispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
+            {
+                var file = await picker.PickSingleFileAsync();
+                if (!file.IsAvailable) return;
+
+                var text = await FileIO.ReadTextAsync(file);
+                callback(text);
+            });
+        }
+
+    }
+}
+#endif

--- a/TextToFromFileWithFilePicker.cs
+++ b/TextToFromFileWithFilePicker.cs
@@ -1,3 +1,4 @@
+#if !WINDOWS_UWP
 using System;
 using System.IO;
 using StereoKit.Framework;
@@ -33,3 +34,4 @@ namespace StereoKitPaintTutorial
 
     }
 }
+#endif

--- a/TextToFromFileWithFilePicker.cs
+++ b/TextToFromFileWithFilePicker.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using StereoKit.Framework;
+
+namespace StereoKitPaintTutorial
+{
+    class TextToFromFileWithFilePicker
+    {
+        static string defaultFolder = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+
+        public static void Load(Action<string> callback)
+        {
+            FilePicker.Show(
+                FilePickerMode.Open,
+                defaultFolder,
+                callback,
+                new FileFilter("Painting", "*.skp"));
+        }
+
+        public static void Save(string fileData)
+        {
+            Action<string> callback = (string file) =>
+            {
+                File.WriteAllText(file, fileData);
+            };
+
+            FilePicker.Show(
+                FilePickerMode.Save,
+                defaultFolder,
+                callback,
+                new FileFilter("Painting", "*.skp"));
+        }
+
+    }
+}


### PR DESCRIPTION
Due to UWP's intent to sandbox the app and let the user choose file location, [user files have no 'path' and only are accessible through StorageFolder/StorageFile interface](https://docs.microsoft.com/en-us/uwp/api/windows.storage.storagefolder.path#remarks).  Related, the Documents folder is off-limits without [manually adding the capability](https://www.pmichaels.net/2016/11/11/uwp-accessing-documents-library/).

Path concept is hardcoded into the StereoKit FilePicker, but navigating UWP user folders without using the native FilePicker takes a lot of wrangling.  Additionally, the native FilePicker must be run on the UI thread which is only always accessible through CoreWindow.

### Result
Load/Save working on HoloLens 2 device 😃 

### Known issues
Extra path drawing is triggered when entering/exiting the native FilePicker.