### PR TITLE
Feature: Drawing with both hands

### DIFF
--- a/PaletteMenu.cs
+++ b/PaletteMenu.cs
@@ -17,6 +17,7 @@ namespace StereoKitPaintTutorial
         
         // These properties are public, so back in Program.cs, we can get access to
         // these values!
+        public Pose Pose { get{ return _pose;  } set{ _pose  = value; } }
         public Color PaintColor { get{ return _color; } private set{ _color = value; } }
         public float PaintSize  { get{ return _size;  } private set{ _size  = value; } }
 

--- a/Program.cs
+++ b/Program.cs
@@ -48,6 +48,7 @@ namespace StereoKitPaintTutorial
             {
                 // Send input information to the painting, it will handle this info to create
                 // brush strokes. This will also draw the painting too!
+                activePainting.Step(Handed.Left, paletteMenu.PaintColor, paletteMenu.PaintSize);
                 activePainting.Step(Handed.Right, paletteMenu.PaintColor, paletteMenu.PaintSize);
 
                 // Step our palette UI!

--- a/Program.cs
+++ b/Program.cs
@@ -42,6 +42,7 @@ namespace StereoKitPaintTutorial
             // UI object for manipulating our brush stroke size and color.
             paletteMenuLeft = new PaletteMenu();
             paletteMenuRight = new PaletteMenu();
+            paletteMenuRight.Pose = new Pose(new Vec3(0.1f, 0, -0.4f), Quat.LookDir(-0.25f, 0, 1));
 
             // Step the application each frame, until StereoKit is told to exit! The callback
             // code here is called every frame after input and system events, but before the

--- a/Program.cs
+++ b/Program.cs
@@ -8,7 +8,8 @@ namespace StereoKitPaintTutorial
     class Program
     {
         static Painting    activePainting = new Painting();
-        static PaletteMenu paletteMenu;
+        static PaletteMenu paletteMenuLeft;
+        static PaletteMenu paletteMenuRight;
         static Pose        menuPose       = new Pose(new Vec3(0.4f, 0, -0.4f), Quat.LookDir(-1,0,1));
         static string      defaultFolder  = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
@@ -39,7 +40,8 @@ namespace StereoKitPaintTutorial
 
             // Initialize the palette menu, see PaletteMenu.cs! This class manages the palette
             // UI object for manipulating our brush stroke size and color.
-            paletteMenu = new PaletteMenu();
+            paletteMenuLeft = new PaletteMenu();
+            paletteMenuRight = new PaletteMenu();
 
             // Step the application each frame, until StereoKit is told to exit! The callback
             // code here is called every frame after input and system events, but before the
@@ -48,11 +50,12 @@ namespace StereoKitPaintTutorial
             {
                 // Send input information to the painting, it will handle this info to create
                 // brush strokes. This will also draw the painting too!
-                activePainting.Step(Handed.Left, paletteMenu.PaintColor, paletteMenu.PaintSize);
-                activePainting.Step(Handed.Right, paletteMenu.PaintColor, paletteMenu.PaintSize);
+                activePainting.Step(Handed.Left, paletteMenuLeft.PaintColor, paletteMenuLeft.PaintSize);
+                activePainting.Step(Handed.Right, paletteMenuRight.PaintColor, paletteMenuRight.PaintSize);
 
                 // Step our palette UI!
-                paletteMenu.Step();
+                paletteMenuLeft.Step();
+                paletteMenuRight.Step();
 
                 // Step our application's menu! This includes Save/Load Clear and Quit commands.
                 StepMenuWindow();


### PR DESCRIPTION
As requested by audience at StereoKit Reactor Redmond meetup, this feature adds support for drawing with both hands.  I considered a couple approaches, but extending a single Painting to track, load, undo/redo, and serialize/unserialize both hands seemed simpler than adding a Painting for each hand.  Plus, I'm left-handed so this is particularly satisfying to me.

### Features
- Both hands can draw simultaneously
- Each hand can draw in a different color
- Palette for left hand appears on the left, right hand appears on the right
- Palette extended so pose can be set externally, making it easier to run multiple Palette instances

### Known issues
Both hands change color with the last-touched palette.  (AIUI this is a limitation of StereoKit which uses the same material for both hands.)